### PR TITLE
Introduce leak safe API

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn main() {
         .with_crate(crate_dir)
         .with_language(cbindgen::Language::C)
         .with_no_includes()
+        .with_include("stddef.h")
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file(out_path);

--- a/sample.c
+++ b/sample.c
@@ -1,6 +1,6 @@
+#include "rakaly.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "rakaly.h"
 
 long read_file(char const *path, char **buf) {
   FILE *fp = fopen(path, "rb");
@@ -39,35 +39,60 @@ long read_file(char const *path, char **buf) {
   return offset;
 }
 
-int melt(char* buf_in, size_t buf_in_len) {
+int melt(char *buf_in, size_t buf_in_len) {
   char *out_buf;
   size_t out_size;
-  char res = rakaly_eu4_melt(buf_in, buf_in_len, &out_buf, &out_size);
-  if (res != 0) {
-    perror("unable to melt save");
+  MeltedBuffer *melt = rakaly_eu4_melt(buf_in, buf_in_len);
+  if (rakaly_melt_error_code(melt)) {
+    rakaly_free_melt(melt);
+    fprintf(stderr, "unable to melt save\n");
     return 1;
   }
 
-  if (fwrite(out_buf, out_size, 1, stdout) == -1) {
-    perror("unable to write to stdout");
+  size_t melted_len = rakaly_melt_data_length(melt);
+  size_t melted_str_len = melted_len + 1;
+  char *melted_buf = malloc(melted_str_len);
+
+  if (melted_buf == NULL) {
+    rakaly_free_melt(melt);
+    fprintf(stderr, "unable to allocate melted data\n");
     return 1;
   }
 
+  size_t wrote_len = rakaly_melt_write_data(melt, melted_buf, melted_str_len);
+  if (wrote_len < 0) {
+    free(melted_buf);
+    rakaly_free_melt(melt);
+    fprintf(stderr, "unable to write melted data\n");
+    return 1;
+  }
+
+  rakaly_free_melt(melt);
+
+  if (fwrite(melted_buf, melted_len, 1, stdout) == -1) {
+    free(melted_buf);
+    fprintf(stderr, "unable to write to stdout\n");
+    return 1;
+  }
+
+  free(melted_buf);
   return 0;
 }
 
 int main(int argc, char **argv) {
   if (argc != 2) {
-    perror("expected one ironman file argument");
+    fprintf(stderr, "expected one ironman file argument\n");
     return 1;
   }
 
   char *buf;
   long file_size = read_file(argv[1], &buf);
   if (file_size == -1) {
-    perror("unable to get read file");
+    fprintf(stderr, "unable to get read file\n");
     return 1;
   }
 
-  return melt(buf, (size_t)file_size);
+  int ret = melt(buf, (size_t)file_size);
+  free(buf);
+  return ret;
 }


### PR DESCRIPTION
Previously rakaly_eu4_melt would modify a the given out pointer to point
to rust allocated chunk of data. There is no way for callers to
deallocate this data safely, so right now this is causing memory leaks.

This can be seen in the sample.c. When ran under valgrind, it will
complain about memory leaks:

```
LEAK SUMMARY:
   definitely lost: 5,056,975 bytes in 1 blocks
   indirectly lost: 0 bytes in 0 blocks
     possibly lost: 75,353,864 bytes in 1 blocks
   still reachable: 0 bytes in 0 blocks
        suppressed: 0 bytes in 0 blocks
```

The fix is to introduce an API that that allows the caller to free the
allocated structure (`MeltedBuffer`).

In addition the fix is to also provide a function that copies the melted
data to a caller provided buffer that has the correct length. An
alternative design was to provide a pointer to the melted buffer data
directly but then we'd run the risk that the caller could hold onto the
data after `rakaly_melt_free` was called.

After updating sample.c to use the new API, valgrind memcheck passed.

Here's the new API in action:

```c
  MeltedBuffer *melt = rakaly_eu4_melt(buf_in, buf_in_len);
  if (rakaly_melt_error_code(melt)) {
    fprintf(stderr, "unable to melt save\n");
    return 1;
  }

  size_t melted_len = rakaly_melt_data_length(melt);
  size_t melted_str_len = melted_len + 1;
  char *melted_buf = malloc(melted_str_len);

  if (melted_buf == NULL) {
    rakaly_free_melt(melt);
    fprintf(stderr, "unable to allocate melted data\n");
    return 1;
  }

  size_t wrote_len = rakaly_melt_write_data(melt, melted_buf, melted_str_len);
  if (wrote_len < 0) {
    rakaly_free_melt(melt);
    fprintf(stderr, "unable to write melted data\n");
    return 1;
  }

  rakaly_free_melt(melt);

  if (fwrite(melted_buf, melted_len, 1, stdout) == -1) {
    free(melted_buf);
    fprintf(stderr, "unable to write to stdout\n");
    return 1;
  }

  free(melted_buf);
```