### PR TITLE
Generate a C++ compatible rakaly.h header

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,13 @@ fn main() {
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let out_path = Path::new(&crate_dir).join("target").join("rakaly.h");
 
+    let config = cbindgen::Config {
+        cpp_compat: true,
+        ..Default::default()
+    };
+
     cbindgen::Builder::new()
+        .with_config(config)
         .with_crate(crate_dir)
         .with_language(cbindgen::Language::C)
         .with_no_includes()

--- a/rakaly_wrapper.h
+++ b/rakaly_wrapper.h
@@ -1,12 +1,9 @@
 #ifndef RAKALY_WRAPPER_H
 #define RAKALY_WRAPPER_H
 
+#include "rakaly.h"
 #include <stdexcept>
 #include <string>
-
-extern "C" {
-#include "rakaly.h"
-}
 
 namespace rakaly {
 
@@ -34,7 +31,7 @@ inline std::string meltEU4(const std::string &encrypted) {
   return meltFinish(rakaly_eu4_melt(encrypted.c_str(), encrypted.length()));
 }
 
-inline std::string meltCK3(const std::string& encrypted) {
+inline std::string meltCK3(const std::string &encrypted) {
   return meltFinish(rakaly_ck3_melt(encrypted.c_str(), encrypted.length()));
 }
 


### PR DESCRIPTION
This allows the header to be used in C code as well as remove the
`extern "C"` block in the C++ wrapper

Also ran `clang-format rakaly_wrapper.h`