### PR TITLE
Enable C/C++ error checks in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,5 +54,5 @@ jobs:
         cp ../sample.cpp .
         cp ../rakaly_wrapper.h .
         cp ./debug/librakaly.so .
-        gcc sample.c -o melter -O3 librakaly.so
-        clang++ sample.cpp -std=c++17 librakaly.so
+        gcc sample.c -o melter -Werror -Wall -Wextra -O3 librakaly.so
+        clang++ sample.cpp -o meltercpp -Werror -Wall -Wextra -std=c++17 librakaly.so

--- a/sample.c
+++ b/sample.c
@@ -40,8 +40,6 @@ long read_file(char const *path, char **buf) {
 }
 
 int melt(char *buf_in, size_t buf_in_len) {
-  char *out_buf;
-  size_t out_size;
   MeltedBuffer *melt = rakaly_eu4_melt(buf_in, buf_in_len);
   if (rakaly_melt_error_code(melt)) {
     rakaly_free_melt(melt);
@@ -60,7 +58,7 @@ int melt(char *buf_in, size_t buf_in_len) {
   }
 
   size_t wrote_len = rakaly_melt_write_data(melt, melted_buf, melted_str_len);
-  if (wrote_len < 0) {
+  if (wrote_len != melted_str_len) {
     free(melted_buf);
     rakaly_free_melt(melt);
     fprintf(stderr, "unable to write melted data\n");
@@ -69,7 +67,7 @@ int melt(char *buf_in, size_t buf_in_len) {
 
   rakaly_free_melt(melt);
 
-  if (fwrite(melted_buf, melted_len, 1, stdout) == -1) {
+  if (fwrite(melted_buf, melted_len, 1, stdout) != 1) {
     free(melted_buf);
     fprintf(stderr, "unable to write to stdout\n");
     return 1;


### PR DESCRIPTION
https://github.com/rakaly/librakaly/pull/6 fixed a compiler warning. This should have been caught in CI, so this PR adds the checks so that future warnings will fail the build.

This PR also includes a commit fixing the warnings in `sample.c`