### PR TITLE
Avoid forcing a null terminator to be written to the provided buffer

### DIFF
--- a/rakaly_wrapper.h
+++ b/rakaly_wrapper.h
@@ -15,7 +15,7 @@ inline std::string meltFinish(MeltedBuffer *melt) {
                              std::to_string(result));
   }
 
-  size_t len = rakaly_melt_data_length(melt) + 1;
+  size_t len = rakaly_melt_data_length(melt);
   std::string str(len, ' ');
 
   if (rakaly_melt_write_data(melt, str.data(), len) != len) {

--- a/sample.c
+++ b/sample.c
@@ -48,8 +48,10 @@ int melt(char *buf_in, size_t buf_in_len) {
   }
 
   size_t melted_len = rakaly_melt_data_length(melt);
-  size_t melted_str_len = melted_len + 1;
-  char *melted_buf = malloc(melted_str_len);
+
+  // Create buffer to store plaintext + 1 additional character to guarantee
+  // null termination in case we need that behavior in the future.
+  char *melted_buf = calloc(melted_len + 1, sizeof(char));
 
   if (melted_buf == NULL) {
     rakaly_free_melt(melt);
@@ -57,8 +59,8 @@ int melt(char *buf_in, size_t buf_in_len) {
     return 1;
   }
 
-  size_t wrote_len = rakaly_melt_write_data(melt, melted_buf, melted_str_len);
-  if (wrote_len != melted_str_len) {
+  size_t wrote_len = rakaly_melt_write_data(melt, melted_buf, melted_len);
+  if (wrote_len != melted_len) {
     free(melted_buf);
     rakaly_free_melt(melt);
     fprintf(stderr, "unable to write melted data\n");

--- a/sample.cpp
+++ b/sample.cpp
@@ -17,7 +17,7 @@ std::string readFile(fs::path path) {
 
 int main(int argc, const char *argv[]) {
   if (argc != 2) {
-    fprintf(stderr, "expected one ironman file argument\n");
+    std::cerr << "expected one ironman file argument\n";
     return 1;
   }
   std::string input = readFile(argv[1]);


### PR DESCRIPTION
There's an issue where `rakaly_melt_write_data` writes a null terminator
into the provided buffer even though the caller may not want a null
terminator.

This is apparent in the following c++ wrapper:

```cpp
size_t len = rakaly_melt_data_length(melt) + 1;
std::string str(len, ' ');
size_t written = rakaly_melt_write_data(melt, str.data(), len);
```

In the above, the string had to explicitly make room for the null
terminator and since the null terminator is now considered a part of the
string, one must now workaround it. In essence, `string::c_str()` would
cause there to be two trailing nul characters.

The fix is to make it the caller's responsibility for ensuring the
buffer they are working with is null terminated (as shown in `sample.c`).
This in turn, makes the code for everyone more succinct and less error prone,
and not even in `sample.c` does the caller's buffer need to be null terminated as
all the APIs used take in an explicit length