### PR TITLE
Expose meta data API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,10 +66,10 @@ jobs:
         cp ./release/librakaly.so .
 
         g++ sample.cpp -o melter -std=c++17 -Werror -Wall -Wextra -O2 librakaly.so
-        LD_LIBRARY_PATH=. ./melter ../assets/saves/kandy2.bin.eu4 > /dev/null
-        LD_LIBRARY_PATH=. ./melter ../assets/saves/af_Munso_867_Ironman.ck3 > /dev/null
-        LD_LIBRARY_PATH=. ./melter ../assets/saves/observer1.5.rome > /dev/null
-        LD_LIBRARY_PATH=. ./melter ../assets/saves/1.10-ironman.hoi4 > /dev/null
+        LD_LIBRARY_PATH=. ./melter save ../assets/saves/kandy2.bin.eu4 > /dev/null
+        LD_LIBRARY_PATH=. ./melter save ../assets/saves/af_Munso_867_Ironman.ck3 > /dev/null
+        LD_LIBRARY_PATH=. ./melter save ../assets/saves/observer1.5.rome > /dev/null
+        LD_LIBRARY_PATH=. ./melter save ../assets/saves/1.10-ironman.hoi4 > /dev/null
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Run verifier (windows)
       if: matrix.os == 'windows-latest'
@@ -79,7 +79,7 @@ jobs:
         cp .\release\rakaly* .
 
         cl /EHsc sample.cpp /std:c++17 /link rakaly.dll.lib /out:melter.exe
-        .\melter.exe ..\assets\saves\kandy2.bin.eu4
-        .\melter.exe ..\assets\saves\af_Munso_867_Ironman.ck3
-        .\melter.exe ..\assets\saves\observer1.5.rome
-        .\melter.exe ..\assets\saves\1.10-ironman.hoi4
+        .\melter.exe save ..\assets\saves\kandy2.bin.eu4 > NUL
+        .\melter.exe save ..\assets\saves\af_Munso_867_Ironman.ck3 > NUL
+        .\melter.exe save ..\assets\saves\observer1.5.rome > NUL
+        .\melter.exe save ..\assets\saves\1.10-ironman.hoi4 > NUL

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ck3save"
 version = "0.4.3"
-source = "git+https://github.com/rakaly/ck3save.git#5fb52ec015e31f3c10c63011bec03c4d32957085"
+source = "git+https://github.com/rakaly/ck3save.git#ce62180f5a067fe0dd0c071373ccd60a8d914e66"
 dependencies = [
  "jomini",
  "libdeflater",
@@ -125,8 +125,7 @@ dependencies = [
 [[package]]
 name = "eu4save"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efe8a2f7c342e13c074326cdad64b67892fbcbc21e2fac34802ff94a43db09a"
+source = "git+https://github.com/rakaly/eu4save.git#9c2dac48813e8f74341a50dd1651741eec217da8"
 dependencies = [
  "jomini",
  "libdeflater",
@@ -172,8 +171,7 @@ dependencies = [
 [[package]]
 name = "hoi4save"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110351713431df4d395c31e1633aefbec285e51b867a554299c00875ea5eda58"
+source = "git+https://github.com/rakaly/hoi4save.git#f1589b96d62ab40c9f3ac792fff25703b5178304"
 dependencies = [
  "jomini",
  "serde",
@@ -183,7 +181,7 @@ dependencies = [
 [[package]]
 name = "imperator-save"
 version = "0.4.2"
-source = "git+https://github.com/rakaly/imperator-save.git#7ad89a7290be71bd320a9495657703deefae60ca"
+source = "git+https://github.com/rakaly/imperator-save.git#b6f3f6fff0e5f9367ecef49ee027c38545169368"
 dependencies = [
  "jomini",
  "libdeflater",
@@ -219,9 +217,9 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jomini"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e86d4b770f0ef605045a909617ffa9808e8e9ffa9a2d5457cc6d4df8c59b0d2"
+checksum = "d725fbaacebb9e663b0070ab631e18674c6e517dd40b23e4db04d49100a88a89"
 dependencies = [
  "jomini_derive",
  "serde",
@@ -272,6 +270,7 @@ dependencies = [
  "hoi4save",
  "imperator-save",
  "libc",
+ "thiserror",
  "vic3save",
 ]
 
@@ -468,7 +467,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "vic3save"
 version = "0.1.0"
-source = "git+https://github.com/pdx-tools/pdx-tools#7d42d9dfebdcf8865f9a8dfd784f29f94933dd1e"
+source = "git+https://github.com/pdx-tools/pdx-tools#2d1f869c46f05e5a7298145ba5038fd9c2f8a2fd"
 dependencies = [
  "jomini",
  "libdeflater",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,12 @@ name = "rakaly"
 
 [dependencies]
 libc = "0.2"
-eu4save = { version = "0.8", default-features = false, features = ["libdeflate"] }
+eu4save = { git = "https://github.com/rakaly/eu4save.git", default-features = false, features = ["libdeflate"] }
 imperator-save = { git = "https://github.com/rakaly/imperator-save.git", default-features = false, features = ["libdeflate"] }
 ck3save = { git = "https://github.com/rakaly/ck3save.git", default-features = false, features = ["libdeflate"] }
-hoi4save = "0.3"
+hoi4save = { git = "https://github.com/rakaly/hoi4save.git" }
 vic3save = { git = "https://github.com/pdx-tools/pdx-tools", features = ["libdeflate"]  }
+thiserror = "1.0"
 
 [build-dependencies]
 cbindgen = "0.20"

--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@
 
 librakaly is a shared library for [PDX Tools](https://pdx.tools/eu4) functionality that exposes a C and C++ interface and can be embedded in any application that can call C or C++ code.
 
-Below is a whirlwind tour of the C++ API.
+Below is a whirlwind tour of the C++ API (for more usage, see `sample.cpp`).
 
 ```cpp
 namespace fs = std::filesystem;
 
-rakaly::MeltedOutput meltPath(fs::path filePath, const std::string &input) {
+rakaly::GameFile parseSave(fs::path filePath, const std::string &input) {
   if (filePath.extension() == ".eu4") {
-    return rakaly::meltEu4(input);
+    return rakaly::parseEu4(input);
   } else if (filePath.extension() == ".ck3") {
-    return rakaly::meltCk3(input);
+    return rakaly::parseCk3(input);
   } else if (filePath.extension() == ".hoi4") {
-    return rakaly::meltHoi4(input);
+    return rakaly::parseHoi4(input);
   } else if (filePath.extension() == ".rome") {
-    return rakaly::meltImperator(input);
+    return rakaly::parseImperator(input);
   } else if (filePath.extension() == ".v3") {
-    return rakaly::meltVic3(input);
+    return rakaly::parseVic3(input);
   } else {
     throw std::runtime_error("unrecognized file extension");
   }
@@ -27,16 +27,18 @@ rakaly::MeltedOutput meltPath(fs::path filePath, const std::string &input) {
 
 int main(int argc, const char *argv[]) {
   // ... snip getting file path and reading file ...
-  const auto melted = meltPath(filePath, input);
-  if (melted.was_binary()) {
-    std::cerr << "cool! This was converted from binary\n";
-    if (melted.has_unknown_tokens()) {
-      std::cerr << "but some fields could not be converted\n";
-      std::cerr << "and will look like '__unknown_0x' in the output\n";
-    }
+  const auto save = parseSave(filePath, input);
+  if (save.is_binary()) {
+    std::cerr << "cool! This save is binary!\n";
   }
 
-  melted.writeData(input);
+  auto melt = save.melt();
+
+  if (melt.has_unknown_tokens()) {
+    std::cerr << "unable to melt all fields\n";
+  }
+
+  melt.writeData(input);
   std::cout << input;
 }
 ```
@@ -53,13 +55,13 @@ While these steps are linux specific, librakaly can also be used with ease on wi
 - Invoke gcc as follows
 
 ```
-gcc sample.c -o melter -O2 librakaly.so
+g++ sample.cpp -std=c++17 -o melter -O2 librakaly.so
 ```
 
 - Then invoke the melter like:
 
 ```
-LD_LIBRARY_PATH=. ./melter my-ironman-save.eu4
+LD_LIBRARY_PATH=. ./melter save my-ironman-save.eu4
 ```
 
 ## Building

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,40 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LibError {
+    #[error("eu4 error: {0}")]
+    Eu4(#[from] eu4save::Eu4Error),
+
+    #[error("ck3 error: {0}")]
+    Ck3(#[from] ck3save::Ck3Error),
+
+    #[error("imperator error: {0}")]
+    Imperator(#[from] imperator_save::ImperatorError),
+
+    #[error("hoi4 error: {0}")]
+    Hoi4(#[from] hoi4save::Hoi4Error),
+
+    #[error("vic3 error: {0}")]
+    Vic3(#[from] vic3save::Vic3Error),
+
+    #[error("panic! Error message may be on stdout/stderr")]
+    Panic,
+}
+
+pub struct PdsError {
+    msg: String,
+}
+
+impl PdsError {
+    pub fn msg(&self) -> &str {
+        self.msg.as_str()
+    }
+}
+
+impl<'a> From<&'a LibError> for PdsError {
+    fn from(value: &'a LibError) -> Self {
+        PdsError {
+            msg: value.to_string(),
+        }
+    }
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,223 @@
+use crate::{errors::LibError, melter::Melter, MeltedBuffer};
+use ck3save::{
+    file::{Ck3Meta, Ck3MetaKind, Ck3ParsedFileKind},
+    Ck3File,
+};
+use eu4save::{
+    file::{Eu4FileEntry, Eu4FileEntryName, Eu4ParsedFileKind},
+    Eu4File,
+};
+use hoi4save::{file::Hoi4ParsedFileKind, Hoi4File};
+use imperator_save::{
+    file::{ImperatorMeta, ImperatorMetaKind, ImperatorParsedFileKind},
+    ImperatorFile,
+};
+use vic3save::{
+    file::{Vic3Meta, Vic3MetaData, Vic3ParsedFileKind},
+    Vic3File,
+};
+
+pub enum PdsFileResult<'a> {
+    Ok(PdsFile<'a>),
+    Err(LibError),
+}
+
+pub enum PdsFile<'a> {
+    Eu4(Eu4File<'a>),
+    Ck3(Ck3File<'a>),
+    Imperator(ImperatorFile<'a>),
+    Hoi4(Hoi4File<'a>),
+    Vic3(Vic3File<'a>),
+}
+
+impl<'a> PdsFile<'a> {
+    pub(crate) fn meta(&self) -> Option<PdsMeta> {
+        match self {
+            PdsFile::Eu4(file) => {
+                let mut entries = file.entries();
+                while let Some(entry) = entries.next_entry() {
+                    if let Some(Eu4FileEntryName::Meta) = entry.name() {
+                        return Some(PdsMeta::Eu4(entry));
+                    }
+                }
+
+                None
+            }
+            PdsFile::Ck3(file) => Some(PdsMeta::Ck3(file.meta())),
+            PdsFile::Imperator(file) => Some(PdsMeta::Imperator(file.meta())),
+            PdsFile::Hoi4(_) => None,
+            PdsFile::Vic3(file) => file.meta().ok().map(PdsMeta::Vic3),
+        }
+    }
+
+    pub(crate) fn melt_file(&self) -> Result<MeltedBuffer, LibError> {
+        match self {
+            PdsFile::Eu4(file) => {
+                if matches!(file.encoding(), eu4save::Encoding::Text) {
+                    return Ok(MeltedBuffer::Verbatim);
+                }
+
+                let mut zip_sink = Vec::new();
+                let parsed = file.parse(&mut zip_sink)?;
+                match parsed.kind() {
+                    Eu4ParsedFileKind::Text(_) => Ok(MeltedBuffer::Text {
+                        header: b"EU4txt".to_vec(),
+                        body: zip_sink,
+                    }),
+                    Eu4ParsedFileKind::Binary(bin) => bin.melt(),
+                }
+            }
+            PdsFile::Ck3(file) => {
+                if matches!(file.encoding(), ck3save::Encoding::Text) {
+                    return Ok(MeltedBuffer::Verbatim);
+                }
+
+                let mut zip_sink = Vec::new();
+                let parsed = file.parse(&mut zip_sink)?;
+                match parsed.kind() {
+                    Ck3ParsedFileKind::Text(_) => {
+                        let mut new_header = file.header().clone();
+                        new_header.set_kind(ck3save::SaveHeaderKind::Text);
+                        let mut out_header = Vec::new();
+                        new_header.write(&mut out_header).unwrap();
+                        Ok(MeltedBuffer::Text {
+                            header: out_header,
+                            body: zip_sink,
+                        })
+                    }
+                    Ck3ParsedFileKind::Binary(bin) => bin.melt(),
+                }
+            }
+            PdsFile::Imperator(file) => {
+                if matches!(file.encoding(), imperator_save::Encoding::Text) {
+                    return Ok(MeltedBuffer::Verbatim);
+                }
+
+                let mut zip_sink = Vec::new();
+                let parsed = file.parse(&mut zip_sink)?;
+                match parsed.kind() {
+                    ImperatorParsedFileKind::Text(_) => {
+                        let mut new_header = file.header().clone();
+                        new_header.set_kind(imperator_save::SaveHeaderKind::Text);
+                        let mut out_header = Vec::new();
+                        new_header.write(&mut out_header).unwrap();
+                        Ok(MeltedBuffer::Text {
+                            header: out_header,
+                            body: zip_sink,
+                        })
+                    }
+                    ImperatorParsedFileKind::Binary(bin) => bin.melt(),
+                }
+            }
+            PdsFile::Hoi4(file) => {
+                if matches!(file.encoding(), hoi4save::Encoding::Plaintext) {
+                    return Ok(MeltedBuffer::Verbatim);
+                }
+
+                let parsed = file.parse()?;
+                match parsed.kind() {
+                    Hoi4ParsedFileKind::Text(_) => Ok(MeltedBuffer::Verbatim),
+                    Hoi4ParsedFileKind::Binary(bin) => bin.melt(),
+                }
+            }
+            PdsFile::Vic3(file) => {
+                if matches!(file.encoding(), vic3save::Encoding::Text) {
+                    return Ok(MeltedBuffer::Verbatim);
+                }
+
+                let mut zip_sink = Vec::new();
+                let parsed = file.parse(&mut zip_sink)?;
+                match parsed.kind() {
+                    Vic3ParsedFileKind::Text(_) => {
+                        let mut new_header = file.header().clone();
+                        new_header.set_kind(vic3save::SaveHeaderKind::Text);
+                        let mut out_header = Vec::new();
+                        new_header.write(&mut out_header).unwrap();
+                        Ok(MeltedBuffer::Text {
+                            header: out_header,
+                            body: zip_sink,
+                        })
+                    }
+                    Vic3ParsedFileKind::Binary(bin) => bin.melt(),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn is_binary(&self) -> bool {
+        match self {
+            PdsFile::Eu4(file) => file.encoding().is_binary(),
+            PdsFile::Ck3(file) => matches!(
+                file.encoding(),
+                ck3save::Encoding::Binary | ck3save::Encoding::BinaryZip
+            ),
+            PdsFile::Imperator(file) => matches!(
+                file.encoding(),
+                imperator_save::Encoding::Binary | imperator_save::Encoding::BinaryZip
+            ),
+            PdsFile::Hoi4(file) => matches!(file.encoding(), hoi4save::Encoding::Binary),
+            PdsFile::Vic3(file) => matches!(
+                file.encoding(),
+                vic3save::Encoding::Binary | vic3save::Encoding::BinaryZip
+            ),
+        }
+    }
+}
+
+pub enum PdsMeta<'data> {
+    Eu4(Eu4FileEntry<'data>),
+    Ck3(Ck3Meta<'data>),
+    Imperator(ImperatorMeta<'data>),
+    Vic3(Vic3Meta<'data>),
+}
+
+impl<'data> PdsMeta<'data> {
+    pub(crate) fn melt(&self) -> Result<MeltedBuffer, LibError> {
+        match self {
+            PdsMeta::Eu4(entry) => {
+                let mut zip_sink = Vec::new();
+                let parsed_entry = entry.parse(&mut zip_sink)?;
+                match parsed_entry.kind() {
+                    Eu4ParsedFileKind::Text(_) => Ok(MeltedBuffer::Text {
+                        header: Vec::new(),
+                        body: zip_sink,
+                    }),
+                    Eu4ParsedFileKind::Binary(binary) => binary.melt(),
+                }
+            }
+            PdsMeta::Ck3(file) => match file.kind() {
+                Ck3MetaKind::Text(x) => {
+                    let mut out_header = Vec::new();
+                    file.header().write(&mut out_header).unwrap();
+                    Ok(MeltedBuffer::Text {
+                        header: out_header,
+                        body: x.to_vec(),
+                    })
+                }
+                Ck3MetaKind::Binary(_) => file.parse()?.as_binary().unwrap().melt(),
+            },
+            PdsMeta::Imperator(file) => match file.kind() {
+                ImperatorMetaKind::Text(x) => {
+                    let mut out_header = Vec::new();
+                    file.header().write(&mut out_header).unwrap();
+                    Ok(MeltedBuffer::Text {
+                        header: out_header,
+                        body: x.to_vec(),
+                    })
+                }
+                ImperatorMetaKind::Binary(_) => file.parse()?.as_binary().unwrap().melt(),
+            },
+            PdsMeta::Vic3(file) => match file.kind() {
+                Vic3MetaData::Text(x) => {
+                    let mut out_header = Vec::new();
+                    file.header().write(&mut out_header).unwrap();
+                    Ok(MeltedBuffer::Text {
+                        header: out_header,
+                        body: x.to_vec(),
+                    })
+                }
+                Vic3MetaData::Binary(_) => file.parse()?.as_binary().unwrap().melt(),
+            },
+        }
+    }
+}

--- a/src/melter.rs
+++ b/src/melter.rs
@@ -1,0 +1,107 @@
+use crate::errors::LibError;
+use ck3save::file::Ck3Binary;
+use eu4save::file::Eu4Binary;
+use hoi4save::file::Hoi4Binary;
+use imperator_save::file::ImperatorBinary;
+use vic3save::file::Vic3Binary;
+
+pub enum MeltedBufferResult {
+    Ok(MeltedBuffer),
+    Err(LibError),
+}
+
+/// An opaque struct that holds the results of the melting operatation
+pub enum MeltedBuffer {
+    Verbatim,
+    Text { header: Vec<u8>, body: Vec<u8> },
+    Binary { body: Vec<u8>, unknown_tokens: bool },
+}
+
+impl MeltedBuffer {
+    pub fn len(&self) -> usize {
+        match self {
+            MeltedBuffer::Verbatim => 0,
+            MeltedBuffer::Text { header, body } => header.len() + body.len(),
+            MeltedBuffer::Binary { body, .. } => body.len(),
+        }
+    }
+}
+
+pub trait Melter {
+    fn melt(&self) -> Result<MeltedBuffer, LibError>;
+}
+
+impl<'a> Melter for &'_ Eu4Binary<'a> {
+    fn melt(&self) -> Result<MeltedBuffer, LibError> {
+        let melted = self
+            .melter()
+            .on_failed_resolve(eu4save::FailedResolveStrategy::Stringify)
+            .verbatim(true)
+            .melt(&eu4save::EnvTokens)?;
+
+        Ok(MeltedBuffer::Binary {
+            unknown_tokens: !melted.unknown_tokens().is_empty(),
+            body: melted.into_data(),
+        })
+    }
+}
+
+impl<'a> Melter for &'_ Ck3Binary<'a> {
+    fn melt(&self) -> Result<MeltedBuffer, LibError> {
+        let melted = self
+            .melter()
+            .on_failed_resolve(ck3save::FailedResolveStrategy::Stringify)
+            .verbatim(true)
+            .melt(&ck3save::EnvTokens)?;
+
+        Ok(MeltedBuffer::Binary {
+            unknown_tokens: !melted.unknown_tokens().is_empty(),
+            body: melted.into_data(),
+        })
+    }
+}
+
+impl<'a> Melter for &'_ ImperatorBinary<'a> {
+    fn melt(&self) -> Result<MeltedBuffer, LibError> {
+        let melted = self
+            .melter()
+            .on_failed_resolve(imperator_save::FailedResolveStrategy::Stringify)
+            .verbatim(true)
+            .melt(&imperator_save::EnvTokens)?;
+
+        Ok(MeltedBuffer::Binary {
+            unknown_tokens: !melted.unknown_tokens().is_empty(),
+            body: melted.into_data(),
+        })
+    }
+}
+
+impl<'a> Melter for &'_ Hoi4Binary<'a> {
+    fn melt(&self) -> Result<MeltedBuffer, LibError> {
+        let melted = self
+            .melter()
+            .on_failed_resolve(hoi4save::FailedResolveStrategy::Stringify)
+            .verbatim(true)
+            .melt(&hoi4save::EnvTokens)?;
+
+        Ok(MeltedBuffer::Binary {
+            unknown_tokens: !melted.unknown_tokens().is_empty(),
+            body: melted.into_data(),
+        })
+    }
+}
+
+impl<'a> Melter for &'_ Vic3Binary<'a> {
+    fn melt(&self) -> Result<MeltedBuffer, LibError> {
+        let melted = self
+            .melter()
+            .on_failed_resolve(vic3save::FailedResolveStrategy::Stringify)
+            .verbatim(true)
+            .melt(&vic3save::EnvTokens)?;
+
+        Ok(MeltedBuffer::Binary {
+            unknown_tokens: !melted.unknown_tokens().is_empty(),
+            body: melted.into_data(),
+        })
+    }
+}


### PR DESCRIPTION
This is a breaking change as the API is no longer geared towards parsing and melting the input in a single step. Instead, there are now a few steps where the API can cheaply load the file and from there the downstream developer can decide what they want to do: melt the metadata first or go straight to melting the main data.