### PR TITLE
Relax glibc requirement by building on ubuntu-20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   create-release:
     name: create-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Create Release
       id: release
@@ -34,7 +34,7 @@ jobs:
         - win-msvc
         include:
         - build: linux
-          os: ubuntu-latest
+          os: ubuntu-20.04
         - build: win-msvc
           os: windows-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
         - win-msvc
         include:
         - build: linux
-          os: ubuntu-latest
+          os: ubuntu-20.04
         - build: macos
           os: macos-latest
         - build: win-msvc
@@ -58,7 +58,7 @@ jobs:
         [ ! -f 1.10-ironman.zip ] && curl -O https://hoi4saves-test-cases.s3.us-west-002.backblazeb2.com/1.10-ironman.zip && unzip 1.10-ironman.zip || true
       working-directory: ./assets/saves
     - name: Run verifier
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-20.04'
       working-directory: ./target
       run: |
         set -eou


### PR DESCRIPTION
By distributing libraries built on ubuntu-22.04, the glibc requirement
is too recent to run on some distros (ie: debian bullseye).