### PR TITLE
Bump linux CI to ubuntu 22.04

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         - win-msvc
         include:
         - build: linux
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - build: macos
           os: macos-latest
         - build: win-msvc
@@ -52,7 +52,7 @@ jobs:
         [ ! -f 1.10-ironman.zip ] && curl -O https://hoi4saves-test-cases.s3.us-west-002.backblazeb2.com/1.10-ironman.zip && unzip 1.10-ironman.zip || true
       working-directory: ./assets/saves
     - name: Run verifier
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-22.04'
       working-directory: ./target
       run: |
         set -eou
@@ -110,7 +110,7 @@ jobs:
 
   release:
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4


### PR DESCRIPTION
Ubuntu 20.04 is no longer supported.

https://github.com/actions/runner-images/issues/11101